### PR TITLE
Add skip_users option

### DIFF
--- a/src/main/java/com/floragunn/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/floragunn/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -265,6 +265,14 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
             authenticatedUser =  Utils.escapeStringRfc2254(user.getName());
         }
 
+        final String[] skipUsers = settings.getAsArray(ConfigConstants.LDAP_AUTHZ_SKIP_USERS, new String[] {});
+        if (Arrays.asList(skipUsers).contains(authenticatedUser)) {
+            if (log.isDebugEnabled()) {
+                log.debug("Skipped search roles of user {}", authenticatedUser);
+            }
+            return;
+        }
+
         LdapEntry entry = null;
         String dn = null;
         Connection connection = null;

--- a/src/main/java/com/floragunn/dlic/auth/ldap/util/ConfigConstants.java
+++ b/src/main/java/com/floragunn/dlic/auth/ldap/util/ConfigConstants.java
@@ -26,6 +26,7 @@ public final class ConfigConstants {
     public static final String LDAP_AUTHZ_ROLESEARCH = "rolesearch";
     public static final String LDAP_AUTHZ_USERROLEATTRIBUTE = "userroleattribute";
     public static final String LDAP_AUTHZ_USERROLENAME = "userrolename";
+    public static final String LDAP_AUTHZ_SKIP_USERS = "skip_users";
     
     public static final String LDAP_HOSTS = "hosts";
     public static final String LDAP_BIND_DN = "bind_dn";


### PR DESCRIPTION
This patch adds skip_user option in ldap authz section, and role-searches of specified users are skipped.
In the case that there is no entry for a certain user in an LDAP such as the user only in a local account, this patch reduces unnecessary LDAP connection.